### PR TITLE
Fix new-user preferences loading + LinkedIn profile autofill

### DIFF
--- a/.claude/launch.json
+++ b/.claude/launch.json
@@ -1,0 +1,11 @@
+{
+  "version": "0.0.1",
+  "configurations": [
+    {
+      "name": "applymate-dev",
+      "runtimeExecutable": "npm",
+      "runtimeArgs": ["run", "dev"],
+      "port": 3000
+    }
+  ]
+}

--- a/src/components/AddJobModal.tsx
+++ b/src/components/AddJobModal.tsx
@@ -54,11 +54,13 @@ export function AddJobModal({ open, onOpenChange, onJobAdded }: AddJobModalProps
     async function loadPreferences() {
       if (!userId) return;
       try {
+        // maybeSingle: a brand-new user may not have a preferences row yet,
+        // which is not an error — matching just won't run.
         const { data, error } = await supabase
           .from("job_preferences")
           .select("*")
           .eq("user_id", userId)
-          .single();
+          .maybeSingle();
 
         if (error) throw error;
         setPreferences(data);

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -197,13 +197,15 @@ export function Index() {
           <div className="mb-8">
             <h1 className="text-3xl font-bold">
               Welcome back
-              {isLoaded ? (
-                user?.user_metadata?.first_name
-                  ? `, ${user.user_metadata.first_name}`
-                  : user?.email
-                    ? `, ${user.email.split('@')[0]}`
-                    : ''
-              ) : '...'}
+              {isLoaded ? (() => {
+                const m = user?.user_metadata || {};
+                const name =
+                  m.first_name ||
+                  m.given_name ||
+                  (m.name || m.full_name || '').split(' ')[0] ||
+                  user?.email?.split('@')[0];
+                return name ? `, ${name}` : '';
+              })() : '...'}
             </h1>
             <p className="text-muted-foreground">
               Manage your job applications on the kanban board below

--- a/src/pages/Profile.tsx
+++ b/src/pages/Profile.tsx
@@ -41,8 +41,14 @@ export default function Profile() {
 
   useEffect(() => {
     if (user) {
-      setFirstName(user.user_metadata?.first_name || '');
-      setLastName(user.user_metadata?.last_name || '');
+      // Prefer our own saved fields, then fall back to OAuth metadata
+      // (LinkedIn OIDC provides given_name/family_name/name, not first/last).
+      const m = user.user_metadata || {};
+      const fullName: string = m.name || m.full_name || '';
+      setFirstName(m.first_name || m.given_name || fullName.split(' ')[0] || '');
+      setLastName(
+        m.last_name || m.family_name || fullName.split(' ').slice(1).join(' ') || ''
+      );
     }
   }, [user]);
   const [preferences, setPreferences] = useState<JobPreferences | null>(null);
@@ -151,7 +157,7 @@ export default function Profile() {
       console.log('Creating new preferences with user_id:', currentUserId);
       const { data: inserted, error: insertError } = await supabase
         .from('job_preferences')
-        .insert(newPrefs)
+        .upsert(newPrefs, { onConflict: 'user_id' })
         .select()
         .single();
 
@@ -172,7 +178,7 @@ export default function Profile() {
       toast({
         variant: 'destructive',
         title: 'Error',
-        description: 'Failed to load preferences'
+        description: error instanceof Error ? error.message : 'Failed to load preferences'
       });
     } finally {
       setLoading(false);

--- a/supabase/migrations/20260630_harden_requesting_user_id.sql
+++ b/supabase/migrations/20260630_harden_requesting_user_id.sql
@@ -1,0 +1,21 @@
+-- Harden requesting_user_id() so RLS reliably resolves the signed-in user.
+--
+-- The previous version only read the aggregated `request.jwt.claims` GUC via
+-- ::json. If PostgREST exposes the subject only via the individual
+-- `request.jwt.claim.sub` GUC (or the aggregate parses differently), the helper
+-- returned NULL — which makes every per-user INSERT fail its WITH CHECK
+-- (e.g. "Failed to load preferences", new jobs not saving) while SELECTs
+-- silently return nothing.
+--
+-- This mirrors Supabase's own auth.uid() implementation: prefer the individual
+-- claim GUC, fall back to the aggregated claims JSON, and cast to uuid.
+create or replace function public.requesting_user_id()
+returns uuid
+language sql
+stable
+as $$
+  select coalesce(
+    nullif(current_setting('request.jwt.claim.sub', true), ''),
+    nullif(current_setting('request.jwt.claims', true), '')::jsonb ->> 'sub'
+  )::uuid;
+$$;


### PR DESCRIPTION
## Problems
After LinkedIn login on the new auth: **"Failed to load preferences"**, **"Add New Job" not working**, and the profile no longer auto-filled name from LinkedIn.

## Root cause
1. **RLS helper too narrow.** `requesting_user_id()` only read the aggregated `request.jwt.claims` GUC. If the subject is exposed via the individual `request.jwt.claim.sub` GUC instead, it returned `NULL`, so every per-user **INSERT** failed its `WITH CHECK` (preferences row never created, new jobs not saved) while SELECTs silently returned nothing. New migration mirrors Supabase's `auth.uid()` (coalesce both claim sources).
2. **`.single()` on a missing row.** `AddJobModal` loaded preferences with `.single()`, which errors when a new user has no preferences row → `.maybeSingle()`.
3. **Profile** now `upsert`s the preferences row and shows the real error message.
4. **LinkedIn autofill.** LinkedIn OIDC populates `given_name`/`family_name`/`name`, not `first_name`/`last_name`. Profile + the Index greeting now map those (preferring our own saved fields).

## Deploy notes
- The migration `supabase/migrations/20260630_harden_requesting_user_id.sql` must be applied to the DB (`supabase db push`) — it's the server-side fix for the INSERT failures.
- The frontend changes deploy with the merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)