### PR TITLE
Fix unclickable Add New Job button on empty board

### DIFF
--- a/src/components/AppSidebar.tsx
+++ b/src/components/AppSidebar.tsx
@@ -57,7 +57,7 @@ export function AppSidebar({ onAddClick, hasJobs }: AppSidebarProps) {
             Add New Job
           </Button>
           {!hasJobs && (
-            <div className="absolute inset-0 rounded-md">
+            <div className="absolute inset-0 rounded-md pointer-events-none">
               <div className="absolute inset-0 rounded-md pulse-ring" />
             </div>
           )}


### PR DESCRIPTION
## Problem
On the main board page, a new user (empty board) could not click **Add New Job** — normal cursor, no response. Worked on sub-pages.

## Cause
When the board is empty (`!hasJobs`), the sidebar shows a decorative pulse-ring. Its absolute overlay wrapper covered the button but lacked `pointer-events: none`, so it swallowed the click.

## Fix
Add `pointer-events-none` to the decorative overlay wrapper so clicks pass through to the button.

🤖 Generated with [Claude Code](https://claude.com/claude-code)