### PR TITLE
Migrate AI job extraction + resume analysis to Claude Haiku

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,8 +5,13 @@ VITE_SUPABASE_ANON_KEY=your-anon-key
 # Logo.dev (company logos)
 VITE_LOGO_API_KEY=your-logo-dev-key
 
-# OpenAI API key (server-side: job analysis, resume parsing). Not VITE_-prefixed
-# so it is never bundled into the client.
+# Anthropic API key (server-side: job extraction + resume analysis via Claude
+# Haiku). Required by the scrape-job and analyze-resume Netlify functions.
+ANTHROPIC_API_KEY=your-anthropic-key
+
+# OpenAI API key (server-side, OPTIONAL): only used for resume embeddings, which
+# feed the currently-disabled job-matching feature. Resume analysis works
+# without it. Not VITE_-prefixed, so it is never bundled into the client.
 OPENAI_API_KEY=your-openai-key
 
 # Netlify functions only — service role bypasses RLS, keep server-side.

--- a/netlify.toml
+++ b/netlify.toml
@@ -75,13 +75,13 @@
 
 [functions.analyze-resume]
   included_files = []
-  external_node_modules = ["pdf-parse", "mammoth", "@langchain/community", "@langchain/openai", "cheerio", "zod", "@supabase/supabase-js"]
+  external_node_modules = ["pdf-parse", "mammoth", "@anthropic-ai/sdk", "openai", "@supabase/supabase-js"]
   environment = { NODE_VERSION = "18.x" }
 
 [functions.scrape-job]
   included_files = []
-  external_node_modules = ["@langchain/community", "@langchain/openai", "cheerio", "zod", "axios", "@supabase/supabase-js"]
-  environment = { NODE_VERSION = "18.x", OPENAI_API_KEY = "${OPENAI_API_KEY}" }
+  external_node_modules = ["@anthropic-ai/sdk", "cheerio", "axios", "@supabase/supabase-js"]
+  environment = { NODE_VERSION = "18.x" }
 
 [functions.find-matching-jobs]
   included_files = []

--- a/netlify/functions/analyze-resume.ts
+++ b/netlify/functions/analyze-resume.ts
@@ -1,25 +1,47 @@
 import { Handler } from '@netlify/functions';
 import OpenAI from 'openai';
-import { ChatOpenAI } from '@langchain/openai';
-import { PromptTemplate } from '@langchain/core/prompts';
-import { StructuredOutputParser } from '@langchain/core/output_parsers';
-import { z } from 'zod';
 import { createClient } from '@supabase/supabase-js';
-import { JobMatch } from './types/job-match';
 import { getVerifiedUserId } from './lib/auth';
+import { extractStructured, aiErrorResponse } from './lib/anthropic';
 
-// Schema for parsed resume data
-const resumeSchema = z.object({
-  skills: z.array(z.string()),
-  experience_level: z.string(),
-  roles: z.array(z.string()),
-  industries: z.array(z.string()),
-  education: z.array(z.string()),
-  languages: z.array(z.string()),
-  years_of_experience: z.number(),
-  key_achievements: z.array(z.string()),
-  locations: z.array(z.string()),
-});
+interface ResumeAnalysis {
+  skills: string[];
+  experience_level: string;
+  roles: string[];
+  industries: string[];
+  education: string[];
+  languages: string[];
+  years_of_experience: number;
+  key_achievements: string[];
+  locations: string[];
+}
+
+// JSON schema for guaranteed-valid structured output from Claude.
+const RESUME_SCHEMA: Record<string, unknown> = {
+  type: 'object',
+  additionalProperties: false,
+  properties: {
+    skills: { type: 'array', items: { type: 'string' } },
+    experience_level: {
+      type: 'string',
+      description: 'One of "Entry Level", "Mid Level", "Senior Level", or "Executive Level"',
+    },
+    roles: { type: 'array', items: { type: 'string' } },
+    industries: { type: 'array', items: { type: 'string' } },
+    education: { type: 'array', items: { type: 'string' } },
+    languages: { type: 'array', items: { type: 'string' } },
+    years_of_experience: { type: 'number' },
+    key_achievements: { type: 'array', items: { type: 'string' } },
+    locations: { type: 'array', items: { type: 'string' } },
+  },
+  required: [
+    'skills', 'experience_level', 'roles', 'industries', 'education',
+    'languages', 'years_of_experience', 'key_achievements', 'locations',
+  ],
+};
+
+const RESUME_SYSTEM_PROMPT =
+  'You analyze resumes and extract structured information. Be thorough — capture both explicit and implicit details. Infer the experience level from roles, responsibilities, and years of experience. For locations, include specific cities and broader regions, current and previous work locations, relocation willingness, and remote preferences.';
 
 // Initialize Supabase client with service role key
 console.log('Environment variables:', {
@@ -74,9 +96,9 @@ export const handler: Handler = async (event) => {
   }
 
   try {
-    // Check OpenAI API key
-    if (!process.env.OPENAI_API_KEY) {
-      throw new Error('OpenAI API key is not configured');
+    // Resume analysis runs on Claude; the AI key is required.
+    if (!process.env.ANTHROPIC_API_KEY) {
+      throw new Error('ANTHROPIC_API_KEY is not configured');
     }
 
     // Identity comes from the verified session token, never the request body.
@@ -148,66 +170,24 @@ export const handler: Handler = async (event) => {
 
     console.log('Extracted text from resume:', text.substring(0, 200) + '...');
 
-    console.log('Starting OpenAI analysis...');
-    // Initialize OpenAI with GPT-3.5 for faster processing
-    const model = new ChatOpenAI({
-      modelName: 'gpt-3.5-turbo',
-      temperature: 0,
-      maxTokens: 1000,
-      openAIApiKey: process.env.OPENAI_API_KEY,
-    });
-
-    // Create parser for structured output
-    const parser = StructuredOutputParser.fromZodSchema(resumeSchema);
-
-    // Create prompt template for resume analysis
-    const promptTemplate = new PromptTemplate({
-      template: `Analyze the following resume content and extract key information.
-      Return a JSON object with these fields:
-      - "skills": Array of technical and soft skills
-      - "experience_level": One of "Entry Level", "Mid Level", "Senior Level", or "Executive Level"
-      - "roles": Array of job titles/roles the person has held or is qualified for
-      - "industries": Array of industries the person has experience in
-      - "education": Array of educational qualifications
-      - "languages": Array of languages the person knows
-      - "years_of_experience": Total years of relevant work experience (number)
-      - "key_achievements": Array of notable achievements or accomplishments
-      - "locations": Array of locations the person has worked in or is willing to work in. Look for:
-          * Current location
-          * Previous work locations
-          * "Willing to relocate" statements
-          * Remote work preferences
-
-      Be thorough in analyzing the entire resume. Look for both explicit and implicit information.
-      Infer the experience level from the roles, responsibilities, and years of experience.
-      For locations, include both specific cities and broader regions (e.g., "San Francisco" and "Bay Area").
-
-      {format_instructions}
-      
-      Resume Content: {resume_content}`,
-      inputVariables: ['resume_content'],
-      partialVariables: {
-        format_instructions: parser.getFormatInstructions(),
-      },
-    });
-
-    // Format prompt with resume content
-    const prompt = await promptTemplate.format({
-      resume_content: text,
-    });
-
-    // Get analysis from OpenAI with timeout handling
-    console.log('Sending prompt to OpenAI...');
-    const response = await Promise.race<any>([
-      model.invoke(prompt),
-      new Promise((_, reject) => 
-        setTimeout(() => reject(new Error('OpenAI analysis timeout')), 20000)
-      )
-    ]) as Awaited<ReturnType<typeof model.invoke>>;
-    
-    console.log('Received OpenAI response, parsing...');
-    const responseText = response.content.toString();
-    const parsedResume = await parser.parse(responseText);
+    console.log('Analyzing resume with Claude...');
+    let parsedResume: ResumeAnalysis;
+    try {
+      parsedResume = await extractStructured<ResumeAnalysis>({
+        system: RESUME_SYSTEM_PROMPT,
+        content: `Analyze this resume and extract the candidate's profile:\n\n${text}`,
+        schema: RESUME_SCHEMA,
+        maxTokens: 1500,
+      });
+    } catch (aiError) {
+      const { statusCode, message } = aiErrorResponse(aiError);
+      console.error('AI resume analysis failed:', aiError);
+      return {
+        statusCode,
+        headers,
+        body: JSON.stringify({ error: 'Failed to analyze resume', details: message }),
+      };
+    }
     console.log('Successfully parsed resume data');
 
     // Update job preferences based on resume analysis
@@ -253,24 +233,28 @@ export const handler: Handler = async (event) => {
 
     console.log('Successfully updated job preferences');
 
-    // Create resume embedding
-    const openai = new OpenAI({
-      apiKey: process.env.OPENAI_API_KEY,
-    });
-
-    const resumeEmbedding = await openai.embeddings.create({
-      model: "text-embedding-ada-002",
-      input: text
-    });
-
-    // Store resume embedding
-    const { error: embeddingError } = await supabase
-      .from('resumes')
-      .update({ embedding: resumeEmbedding.data[0].embedding })
-      .eq('id', resumeId);
-
-    if (embeddingError) {
-      throw new Error('Failed to store resume embedding');
+    // Best-effort: store a resume embedding for the (currently disabled) job
+    // matching feature. Anthropic has no embeddings API, so this still uses
+    // OpenAI — but it must not fail the analysis if OpenAI is unavailable.
+    if (process.env.OPENAI_API_KEY) {
+      try {
+        const openai = new OpenAI({ apiKey: process.env.OPENAI_API_KEY });
+        const resumeEmbedding = await openai.embeddings.create({
+          model: 'text-embedding-3-small',
+          input: text,
+        });
+        const { error: embeddingError } = await supabase
+          .from('resumes')
+          .update({ embedding: resumeEmbedding.data[0].embedding })
+          .eq('id', resumeId);
+        if (embeddingError) {
+          console.warn('Could not store resume embedding:', embeddingError.message);
+        }
+      } catch (embeddingError) {
+        console.warn('Skipping resume embedding (OpenAI unavailable):', embeddingError);
+      }
+    } else {
+      console.log('OPENAI_API_KEY not set — skipping resume embedding.');
     }
 
     return {

--- a/netlify/functions/lib/anthropic.ts
+++ b/netlify/functions/lib/anthropic.ts
@@ -1,0 +1,66 @@
+import Anthropic from '@anthropic-ai/sdk';
+
+// Claude Haiku 4.5: fast and cheap, ideal for extraction; supports native
+// structured outputs (guaranteed-valid JSON against a schema).
+export const EXTRACTION_MODEL = 'claude-haiku-4-5';
+
+let client: Anthropic | null = null;
+
+function getClient(): Anthropic {
+  if (!process.env.ANTHROPIC_API_KEY) {
+    throw new Error('ANTHROPIC_API_KEY is not configured');
+  }
+  if (!client) {
+    client = new Anthropic({ apiKey: process.env.ANTHROPIC_API_KEY });
+  }
+  return client;
+}
+
+/**
+ * Run a structured extraction with Claude. Returns JSON validated against the
+ * provided JSON schema (no fragile prompt-parsing / regex fallback needed).
+ */
+export async function extractStructured<T>(opts: {
+  system: string;
+  content: string;
+  schema: Record<string, unknown>;
+  maxTokens?: number;
+}): Promise<T> {
+  const message = await getClient().messages.create({
+    model: EXTRACTION_MODEL,
+    max_tokens: opts.maxTokens ?? 1024,
+    system: opts.system,
+    messages: [{ role: 'user', content: opts.content }],
+    output_config: { format: { type: 'json_schema', schema: opts.schema } },
+  });
+
+  const textBlock = message.content.find((b) => b.type === 'text');
+  if (!textBlock || textBlock.type !== 'text') {
+    throw new Error('No text content returned from Claude');
+  }
+  return JSON.parse(textBlock.text) as T;
+}
+
+/**
+ * Map a provider/AI error to a clear user-facing message + HTTP status, so the
+ * UI can tell "out of credits" apart from a generic failure.
+ */
+export function aiErrorResponse(error: unknown): { statusCode: number; message: string } {
+  const e = error as { status?: number; error?: { type?: string }; message?: string };
+  const status = e?.status;
+  const type = e?.error?.type;
+
+  if (status === 429) {
+    return { statusCode: 503, message: 'The AI service is rate-limited right now. Please try again in a moment.' };
+  }
+  if (status === 401) {
+    return { statusCode: 500, message: 'AI service authentication failed — check the ANTHROPIC_API_KEY.' };
+  }
+  if (type === 'billing_error' || status === 402) {
+    return { statusCode: 402, message: 'The AI service is out of credits. Please top up the Anthropic account.' };
+  }
+  if (status === 403) {
+    return { statusCode: 500, message: 'AI service access denied (permission or billing issue).' };
+  }
+  return { statusCode: 500, message: e?.message || 'AI processing failed.' };
+}

--- a/netlify/functions/package-lock.json
+++ b/netlify/functions/package-lock.json
@@ -6,6 +6,7 @@
     "": {
       "name": "netlify-functions",
       "dependencies": {
+        "@anthropic-ai/sdk": "^0.109.0",
         "@langchain/community": "^0.3.18",
         "@langchain/openai": "^0.3.14",
         "@netlify/functions": "^2.5.1",
@@ -22,19 +23,24 @@
       }
     },
     "node_modules/@anthropic-ai/sdk": {
-      "version": "0.27.3",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.27.3.tgz",
-      "integrity": "sha512-IjLt0gd3L4jlOfilxVXTifn42FnVffMgDC04RJK1KDZpmkBWLv0XC92MVVmkxrFZNS/7l3xWgP/I3nqtX1sQHw==",
+      "version": "0.109.0",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.109.0.tgz",
+      "integrity": "sha512-y7P4eLyW5uNut4fXpOUEHqhJwx7dnxrWAfCQE4Lcgm0hSFQuIeHa7CWEKE5dFolEjQJE/RFKkppjri05r2OK/Q==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
-        "@types/node": "^18.11.18",
-        "@types/node-fetch": "^2.6.4",
-        "abort-controller": "^3.0.0",
-        "agentkeepalive": "^4.2.1",
-        "form-data-encoder": "1.7.2",
-        "formdata-node": "^4.3.2",
-        "node-fetch": "^2.6.7"
+        "json-schema-to-ts": "^3.1.1",
+        "standardwebhooks": "^1.0.0"
+      },
+      "bin": {
+        "anthropic-ai-sdk": "bin/cli"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.0 || ^4.0.0"
+      },
+      "peerDependenciesMeta": {
+        "zod": {
+          "optional": true
+        }
       }
     },
     "node_modules/@babel/code-frame": {
@@ -43,7 +49,6 @@
       "integrity": "sha512-RJlIHRueQgwWitWgF8OdFYGZX328Ax5BCemNGlqHfplnRT9ESi8JkFlvaVYbS+UubVY6dpv87Fs2u5M29iNFVQ==",
       "license": "MIT",
       "optional": true,
-      "peer": true,
       "dependencies": {
         "@babel/helper-validator-identifier": "^7.25.9",
         "js-tokens": "^4.0.0",
@@ -59,7 +64,15 @@
       "integrity": "sha512-Ed61U6XJc3CVRfkERJWDz4dJwKe7iLmmJsbOGu9wSloNSFttHV0I8g6UAgb7qnK5ly5bGLPd4oXZlxCdANBOWQ==",
       "license": "MIT",
       "optional": true,
-      "peer": true,
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/runtime": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.7.tgz",
+      "integrity": "sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw==",
+      "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
       }
@@ -69,7 +82,6 @@
       "resolved": "https://registry.npmjs.org/@browserbasehq/sdk/-/sdk-2.0.0.tgz",
       "integrity": "sha512-BdPlZyn0dpXlL70gNK4acpqWIRB+edo2z0/GalQdWghRq8iQjySd9fVIF3evKH1p2wCYekZJRK6tm29YfXB67g==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@types/node": "^18.11.18",
         "@types/node-fetch": "^2.6.4",
@@ -85,7 +97,6 @@
       "resolved": "https://registry.npmjs.org/@browserbasehq/stagehand/-/stagehand-1.9.0.tgz",
       "integrity": "sha512-0wIFnwOVnUEgVkPKW0RX7NoOt98qaRJ8+l1m9ppk1f5E03GtefDQTMiQwwT9WQn163bpZT5cOhyA1I3jZNfFeA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@anthropic-ai/sdk": "^0.27.3",
         "@browserbasehq/sdk": "^2.0.0",
@@ -101,12 +112,26 @@
         "zod": "^3.23.8"
       }
     },
+    "node_modules/@browserbasehq/stagehand/node_modules/@anthropic-ai/sdk": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.27.3.tgz",
+      "integrity": "sha512-IjLt0gd3L4jlOfilxVXTifn42FnVffMgDC04RJK1KDZpmkBWLv0XC92MVVmkxrFZNS/7l3xWgP/I3nqtX1sQHw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "^18.11.18",
+        "@types/node-fetch": "^2.6.4",
+        "abort-controller": "^3.0.0",
+        "agentkeepalive": "^4.2.1",
+        "form-data-encoder": "1.7.2",
+        "formdata-node": "^4.3.2",
+        "node-fetch": "^2.6.7"
+      }
+    },
     "node_modules/@cfworker/json-schema": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/@cfworker/json-schema/-/json-schema-4.1.0.tgz",
       "integrity": "sha512-/vYKi/qMxwNsuIJ9WGWwM2rflY40ZenK3Kh4uR5vB9/Nz12Y7IUN/Xf4wDA7vzPfw0VNh3b/jz4+MjcVgARKJg==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@emnapi/runtime": {
       "version": "1.3.1",
@@ -114,7 +139,6 @@
       "integrity": "sha512-kEBmG8KyqtxJZv+ygbEim+KCGtIq1fC22Ms3S4ziXmYKm8uyoLX0MHONVKwp+9opg390VaKRNt4a7A9NwmpNhw==",
       "license": "MIT",
       "optional": true,
-      "peer": true,
       "dependencies": {
         "tslib": "^2.4.0"
       }
@@ -146,7 +170,6 @@
       "os": [
         "darwin"
       ],
-      "peer": true,
       "engines": {
         "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
       },
@@ -169,7 +192,6 @@
       "os": [
         "darwin"
       ],
-      "peer": true,
       "engines": {
         "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
       },
@@ -192,7 +214,6 @@
       "os": [
         "darwin"
       ],
-      "peer": true,
       "funding": {
         "url": "https://opencollective.com/libvips"
       }
@@ -209,7 +230,6 @@
       "os": [
         "darwin"
       ],
-      "peer": true,
       "funding": {
         "url": "https://opencollective.com/libvips"
       }
@@ -226,7 +246,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "funding": {
         "url": "https://opencollective.com/libvips"
       }
@@ -243,7 +262,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "funding": {
         "url": "https://opencollective.com/libvips"
       }
@@ -260,7 +278,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "funding": {
         "url": "https://opencollective.com/libvips"
       }
@@ -277,7 +294,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "funding": {
         "url": "https://opencollective.com/libvips"
       }
@@ -294,7 +310,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "funding": {
         "url": "https://opencollective.com/libvips"
       }
@@ -311,7 +326,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "funding": {
         "url": "https://opencollective.com/libvips"
       }
@@ -328,7 +342,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
       },
@@ -351,7 +364,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
       },
@@ -374,7 +386,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
       },
@@ -397,7 +408,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
       },
@@ -420,7 +430,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
       },
@@ -443,7 +452,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
       },
@@ -463,7 +471,6 @@
       ],
       "license": "Apache-2.0 AND LGPL-3.0-or-later AND MIT",
       "optional": true,
-      "peer": true,
       "dependencies": {
         "@emnapi/runtime": "^1.2.0"
       },
@@ -486,7 +493,6 @@
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
       },
@@ -506,7 +512,6 @@
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
       },
@@ -1141,7 +1146,6 @@
       "integrity": "sha512-aBSREisdsGH890S2rQqK82qmQYU3uFpSH8wcZWHgHzl3LfzsxAKbLNiAG9mO8v1Y0UICBeClICxPJvyr0rcuxg==",
       "license": "Apache-2.0",
       "optional": true,
-      "peer": true,
       "dependencies": {
         "debug": "^4.4.0",
         "extract-zip": "^2.0.1",
@@ -1171,6 +1175,12 @@
       "engines": {
         "node": ">= 16"
       }
+    },
+    "node_modules/@stablelib/base64": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@stablelib/base64/-/base64-1.0.1.tgz",
+      "integrity": "sha512-1bnPQqSxSuc3Ii6MhBysoWCg58j97aUjuCSZrGSmDxNqtytIi0k8utUenAwTZN4V5mXXYGsVUI9zeBqy+jBOSQ==",
+      "license": "MIT"
     },
     "node_modules/@supabase/auth-js": {
       "version": "2.67.3",
@@ -1237,6 +1247,7 @@
       "resolved": "https://registry.npmjs.org/@supabase/supabase-js/-/supabase-js-2.47.16.tgz",
       "integrity": "sha512-FnoV0miLnYUL8ZTS94tSIyn+ogCwh5DB5f1fj1n4wHGNAqJSKFb8OQzLVlRFAH7cB9TKQ5eon3/n2lXUWY7GfA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@supabase/auth-js": "2.67.3",
         "@supabase/functions-js": "2.4.4",
@@ -1250,23 +1261,20 @@
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/@tokenizer/token/-/token-0.3.0.tgz",
       "integrity": "sha512-OvjF+z51L3ov0OyAU0duzsYuvO01PH7x4t6DJx+guahgTnBHkhJdG7soQeTSFLWN3efnHyibZ4Z8l2EuWwJN3A==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@tootallnate/quickjs-emscripten": {
       "version": "0.23.0",
       "resolved": "https://registry.npmjs.org/@tootallnate/quickjs-emscripten/-/quickjs-emscripten-0.23.0.tgz",
       "integrity": "sha512-C5Mc6rdnsaJDjO3UpGW/CQTHtCKaYlScZTly4JIu97Jxo/odCiH0ITnDXSJPTOrEKk/ycSZ0AOgTmkDtkOsvIA==",
       "license": "MIT",
-      "optional": true,
-      "peer": true
+      "optional": true
     },
     "node_modules/@types/debug": {
       "version": "4.1.12",
       "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.12.tgz",
       "integrity": "sha512-vIChWdVG3LG1SMxEvI/AK+FWJthlrqlTu7fbrlywTkkaONwk/UAGaULXRlf8vkzFBLVm0zkMdCquhL5aOjhXPQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/ms": "*"
       }
@@ -1275,8 +1283,7 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/@types/ms/-/ms-2.1.0.tgz",
       "integrity": "sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@types/node": {
       "version": "18.19.68",
@@ -1313,8 +1320,7 @@
       "version": "4.0.5",
       "resolved": "https://registry.npmjs.org/@types/tough-cookie/-/tough-cookie-4.0.5.tgz",
       "integrity": "sha512-/Ad8+nIOV7Rl++6f1BdKxFSMgmoqEoYbHRpPcx3JEfv8VRsQe9Z4mCXeJBzxs7mbHY/XOZZuXlRNfhpVPbs6ZA==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@types/uuid": {
       "version": "10.0.0",
@@ -1368,7 +1374,6 @@
       "integrity": "sha512-jRR5wdylq8CkOe6hei19GGZnxM6rBGwFl3Bg0YItGDimvjGtAvdZk4Pu6Cl4u4Igsws4a1fd1Vq3ezrhn4KmFw==",
       "license": "MIT",
       "optional": true,
-      "peer": true,
       "engines": {
         "node": ">= 14"
       }
@@ -1399,7 +1404,6 @@
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
       "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -1419,7 +1423,6 @@
       "integrity": "sha512-x1FCFnFifvYDDzTaLII71vG5uvDwgtmDTEVWAxrgeiR8VjMONcCXJx7E+USjDtHlwFmt9MysbqgF9b9Vjr6w+w==",
       "license": "MIT",
       "optional": true,
-      "peer": true,
       "dependencies": {
         "tslib": "^2.0.1"
       },
@@ -1438,6 +1441,7 @@
       "resolved": "https://registry.npmjs.org/axios/-/axios-1.7.9.tgz",
       "integrity": "sha512-LhLcE7Hbiryz8oMDdDptSrWowmB4Bl6RCt6sIJKpRB4XtVf0iEgewX3au/pJqm+Py1kCASkb/FFKjxQaLtxJvw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "follow-redirects": "^1.15.6",
         "form-data": "^4.0.0",
@@ -1540,7 +1544,6 @@
       "integrity": "sha512-4Bcg1P8xhUuqcii/S0Z9wiHIrQVPMermM1any+MX5GeGD7faD3/msQUDGLol9wOcz4/jbg/WJnGqoJF6LiBdtg==",
       "license": "MIT",
       "optional": true,
-      "peer": true,
       "engines": {
         "node": ">=10.0.0"
       }
@@ -1631,8 +1634,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
       "integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==",
-      "license": "BSD-3-Clause",
-      "peer": true
+      "license": "BSD-3-Clause"
     },
     "node_modules/callsites": {
       "version": "3.1.0",
@@ -1640,7 +1642,6 @@
       "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
       "license": "MIT",
       "optional": true,
-      "peer": true,
       "engines": {
         "node": ">=6"
       }
@@ -1650,7 +1651,6 @@
       "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.3.0.tgz",
       "integrity": "sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -1663,6 +1663,7 @@
       "resolved": "https://registry.npmjs.org/cheerio/-/cheerio-1.0.0.tgz",
       "integrity": "sha512-quS9HgjQpdaXOvsZz82Oz7uxtXiy6UIsIQcpBj7HRw2M63Skasm9qlDocAM7jNuaxdhpPU7c4kJN+gA5MCu4ww==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "cheerio-select": "^2.1.0",
         "dom-serializer": "^2.0.0",
@@ -1712,7 +1713,6 @@
       "integrity": "sha512-6CJWHkNRoyZyjV9Rwv2lYONZf1Xm0IuDyNq97nwSsxxP3wf5Bwy15K5rOvVKMtJ127jJBmxFUanSAOjgFRxgrA==",
       "license": "Apache-2.0",
       "optional": true,
-      "peer": true,
       "dependencies": {
         "mitt": "3.0.1",
         "zod": "3.23.8"
@@ -1727,7 +1727,6 @@
       "integrity": "sha512-XBx9AXhXktjUqnepgTiE5flcKIYWi/rme0Eaj+5Y0lftuGBq+jyRu/md4WnuxqgP1ubdpNCsYEYPxrzVHD8d6g==",
       "license": "MIT",
       "optional": true,
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }
@@ -1751,7 +1750,6 @@
       "resolved": "https://registry.npmjs.org/color/-/color-4.2.3.tgz",
       "integrity": "sha512-1rXeuUUiGGrykh+CeBdu5Ie7OJwinCgQY0bc7GCRxy5xVHy+moaqkpL/jqQq0MtQOeYcrqEz4abc5f0KtU7W4A==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "color-convert": "^2.0.1",
         "color-string": "^1.9.0"
@@ -1783,7 +1781,6 @@
       "resolved": "https://registry.npmjs.org/color-string/-/color-string-1.9.1.tgz",
       "integrity": "sha512-shrVawQFojnZv6xM40anx4CkoDP+fZsw/ZerEMsW/pyzsRbElpsL/DBVW7q3ExxwusdNXI3lXpuhEZkzs8p5Eg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "color-name": "^1.0.0",
         "simple-swizzle": "^0.2.2"
@@ -1822,7 +1819,6 @@
       "integrity": "sha512-itvL5h8RETACmOTFc4UfIyB2RfEHi71Ax6E/PivVxq9NseKbOWpeyHEOIbmAw1rs8Ak0VursQNww7lf7YtUwzg==",
       "license": "MIT",
       "optional": true,
-      "peer": true,
       "dependencies": {
         "env-paths": "^2.2.1",
         "import-fresh": "^3.3.0",
@@ -1907,7 +1903,6 @@
       "integrity": "sha512-7hvf7/GW8e86rW0ptuwS3OcBGDjIi6SZva7hCyWC0yYry2cOPmLIjXAUHI6DK2HsnwJd9ifmt57i8eV2n4YNpw==",
       "license": "MIT",
       "optional": true,
-      "peer": true,
       "engines": {
         "node": ">= 14"
       }
@@ -1934,7 +1929,6 @@
       "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
       "integrity": "sha512-z2S+W9X73hAUUki+N+9Za2lBlun89zigOyGrsax+KUQ6wKW4ZoWpEYBkGhQjwAjjDCkWxhY0VKEhk8wzY7F5cA==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -1955,7 +1949,6 @@
       "integrity": "sha512-TllpMR/t0M5sqCXfj85i4XaAzxmS5tVA16dqvdkMwGmzI+dXLXnw3J+3Vdv7VKw+ThlTMboK6i9rnZ6Nntj5CQ==",
       "license": "MIT",
       "optional": true,
-      "peer": true,
       "dependencies": {
         "ast-types": "^0.13.4",
         "escodegen": "^2.1.0",
@@ -1979,18 +1972,9 @@
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.0.3.tgz",
       "integrity": "sha512-bwy0MGW55bG41VqxxypOsdSdGqLwXPI/focwgTYCFMbdUiBAxLg9CFzG08sz2aqzknwiX7Hkl0bQENjg8iLByw==",
       "license": "Apache-2.0",
-      "peer": true,
       "engines": {
         "node": ">=8"
       }
-    },
-    "node_modules/devtools-protocol": {
-      "version": "0.0.1367902",
-      "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1367902.tgz",
-      "integrity": "sha512-XxtPuC3PGakY6PD7dG66/o8KwJ/LkH2/EKe19Dcw58w53dv4/vSQEkn/SzuyhHE2q4zPgCkxQBxus3VV4ql+Pg==",
-      "license": "BSD-3-Clause",
-      "optional": true,
-      "peer": true
     },
     "node_modules/dingbat-to-unicode": {
       "version": "1.0.1",
@@ -2080,7 +2064,6 @@
       "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
       "integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "safe-buffer": "^5.0.1"
       }
@@ -2131,7 +2114,6 @@
       "integrity": "sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A==",
       "license": "MIT",
       "optional": true,
-      "peer": true,
       "engines": {
         "node": ">=6"
       }
@@ -2142,7 +2124,6 @@
       "integrity": "sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==",
       "license": "MIT",
       "optional": true,
-      "peer": true,
       "dependencies": {
         "is-arrayish": "^0.2.1"
       }
@@ -2162,7 +2143,6 @@
       "integrity": "sha512-2NlIDTwUWJN0mRPQOdtQBzbUHvdGY2P1VXSyU83Q3xKxM7WHX2Ql8dKq782Q9TgQUNOLEzEYu9bzLNj1q88I5w==",
       "license": "BSD-2-Clause",
       "optional": true,
-      "peer": true,
       "dependencies": {
         "esprima": "^4.0.1",
         "estraverse": "^5.2.0",
@@ -2185,7 +2165,6 @@
       "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
       "license": "BSD-2-Clause",
       "optional": true,
-      "peer": true,
       "bin": {
         "esparse": "bin/esparse.js",
         "esvalidate": "bin/esvalidate.js"
@@ -2200,7 +2179,6 @@
       "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
       "license": "BSD-2-Clause",
       "optional": true,
-      "peer": true,
       "engines": {
         "node": ">=4.0"
       }
@@ -2211,7 +2189,6 @@
       "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
       "license": "BSD-2-Clause",
       "optional": true,
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -2241,8 +2218,7 @@
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
       "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/extract-zip": {
       "version": "2.0.1",
@@ -2270,6 +2246,12 @@
       "integrity": "sha512-/d9sfos4yxzpwkDkuN7k2SqFKtYNmCTzgfEpz82x34IM9/zc8KGxQoXg1liNC/izpRM/MBdt44Nmx41ZWqk+FQ==",
       "license": "MIT"
     },
+    "node_modules/fast-sha256": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/fast-sha256/-/fast-sha256-1.3.0.tgz",
+      "integrity": "sha512-n11RGP/lrWEFI/bWdygLxhI+pVeo1ZYIVwvvPkW7azl/rOy+F3HYRZ2K5zeE9mmkhQppyv9sQFx0JM9UabnpPQ==",
+      "license": "Unlicense"
+    },
     "node_modules/fd-slicer": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.1.0.tgz",
@@ -2284,7 +2266,6 @@
       "resolved": "https://registry.npmjs.org/file-type/-/file-type-16.5.4.tgz",
       "integrity": "sha512-/yFHK0aGjFEgDJjEKP0pWCplsPFPhwyfwevf/pVxiN0tmE4L9LmwWxWukdJSHdoCli4VgQLehjJtwQBnqmsKcw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "readable-web-to-node-stream": "^3.0.0",
         "strtok3": "^6.2.4",
@@ -2375,7 +2356,6 @@
       "os": [
         "darwin"
       ],
-      "peer": true,
       "engines": {
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
@@ -2410,7 +2390,6 @@
       "integrity": "sha512-E1b1lFFLvLgak2whF2xDBcOy6NLVGZBqqjJjsIhvopKfWWEi64pLVTWWehV8KlLerZkfNTA95sTe2OdJKm1OzQ==",
       "license": "MIT",
       "optional": true,
-      "peer": true,
       "dependencies": {
         "basic-ftp": "^5.0.2",
         "data-uri-to-buffer": "^6.0.2",
@@ -2445,7 +2424,6 @@
       "integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
       "license": "MIT",
       "optional": true,
-      "peer": true,
       "dependencies": {
         "agent-base": "^7.1.0",
         "debug": "^4.3.4"
@@ -2460,7 +2438,6 @@
       "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
       "license": "MIT",
       "optional": true,
-      "peer": true,
       "dependencies": {
         "agent-base": "^7.1.2",
         "debug": "4"
@@ -2483,7 +2460,6 @@
       "resolved": "https://registry.npmjs.org/ibm-cloud-sdk-core/-/ibm-cloud-sdk-core-5.1.1.tgz",
       "integrity": "sha512-19nSrd8UcCP4q3974wtY+gxwOcD9cQfeVUkpGRWoHs4D7bN+SB5g0m5aPAPa6QjwqDY68EYkQUboEt7dTp+4jQ==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@types/debug": "^4.1.12",
         "@types/node": "~10.14.19",
@@ -2509,15 +2485,13 @@
       "version": "10.14.22",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-10.14.22.tgz",
       "integrity": "sha512-9taxKC944BqoTVjE+UT3pQH0nHZlTvITwfsOZqyc+R3sfJuxaTtxWjfn1K2UlxyPcKHf0rnaXcVFrS9F9vf0bw==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/ibm-cloud-sdk-core/node_modules/axios": {
       "version": "1.7.4",
       "resolved": "https://registry.npmjs.org/axios/-/axios-1.7.4.tgz",
       "integrity": "sha512-DukmaFRnY6AzAALSH4J2M3k6PkaC+MfaAGdEERRWcC9q3/TWQwLpHR8ZRLKTdQ3aBDL64EdluRDjJqKw+BPZEw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "follow-redirects": "^1.15.6",
         "form-data": "^4.0.0",
@@ -2529,7 +2503,6 @@
       "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
       "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "asynckit": "^0.4.0",
         "combined-stream": "^1.0.8",
@@ -2583,7 +2556,6 @@
       "integrity": "sha512-veYYhQa+D1QBKznvhUHxb8faxlrwUnxseDAbAp457E0wLNio2bOSKnjYDhMj+YiAq61xrMGhQk9iXVk5FzgQMw==",
       "license": "MIT",
       "optional": true,
-      "peer": true,
       "dependencies": {
         "parent-module": "^1.0.0",
         "resolve-from": "^4.0.0"
@@ -2607,7 +2579,6 @@
       "integrity": "sha512-zHtQzGojZXTwZTHQqra+ETKd4Sn3vgi7uBmlPoXVWZqYvuKmtI0l/VZTjqGmJY9x88GGOaZ9+G9ES8hC4T4X8g==",
       "license": "MIT",
       "optional": true,
-      "peer": true,
       "dependencies": {
         "jsbn": "1.1.0",
         "sprintf-js": "^1.1.3"
@@ -2621,8 +2592,7 @@
       "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
       "integrity": "sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==",
       "license": "MIT",
-      "optional": true,
-      "peer": true
+      "optional": true
     },
     "node_modules/is-fullwidth-code-point": {
       "version": "3.0.0",
@@ -2643,8 +2613,7 @@
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
       "integrity": "sha512-Yljz7ffyPbrLpLngrMtZ7NduUgVvi6wG9RJ9IUcyCd59YQ911PBJphODUcbOVbqYfxe1wuYf/LJ8PauMRwsM/g==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/js-tiktoken": {
       "version": "1.0.16",
@@ -2660,8 +2629,7 @@
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
       "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
       "license": "MIT",
-      "optional": true,
-      "peer": true
+      "optional": true
     },
     "node_modules/js-yaml": {
       "version": "4.1.0",
@@ -2680,16 +2648,27 @@
       "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-1.1.0.tgz",
       "integrity": "sha512-4bYVV3aAMtDTTu4+xsDYa6sy9GyJ69/amsu9sYF2zqjiEoZA5xJi3BrfX3uY+/IekIu7MwdObdbDWpoZdBv3/A==",
       "license": "MIT",
-      "optional": true,
-      "peer": true
+      "optional": true
     },
     "node_modules/json-parse-even-better-errors": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
       "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==",
       "license": "MIT",
-      "optional": true,
-      "peer": true
+      "optional": true
+    },
+    "node_modules/json-schema-to-ts": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/json-schema-to-ts/-/json-schema-to-ts-3.1.1.tgz",
+      "integrity": "sha512-+DWg8jCJG2TEnpy7kOm/7/AxaYoaRbjVB4LFZLySZlWn8exGs3A4OLJR966cVvU26N7X9TWxl+Jsw7dzAqKT6g==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.18.3",
+        "ts-algebra": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=16"
+      }
     },
     "node_modules/json-stringify-safe": {
       "version": "5.0.1",
@@ -2711,7 +2690,6 @@
       "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-9.0.2.tgz",
       "integrity": "sha512-PRp66vJ865SSqOlgqS8hujT5U4AOgMfhrwYIuIhfKaoSCZcirrmASQr8CX7cUg+RMih+hgznrjp99o+W4pJLHQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "jws": "^3.2.2",
         "lodash.includes": "^4.3.0",
@@ -2746,7 +2724,6 @@
       "resolved": "https://registry.npmjs.org/jwa/-/jwa-1.4.1.tgz",
       "integrity": "sha512-qiLX/xhEEFKUAJ6FiBMbes3w9ATzyk5W7Hvzpa/SLYdxNtng+gcurvrI7TbACjIXlsJyr05/S1oUhZrc63evQA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "buffer-equal-constant-time": "1.0.1",
         "ecdsa-sig-formatter": "1.0.11",
@@ -2758,7 +2735,6 @@
       "resolved": "https://registry.npmjs.org/jws/-/jws-3.2.2.tgz",
       "integrity": "sha512-YHlZCB6lMTllWDtSPHz/ZXTsi8S00usEV6v1tjq8tOUZzw7DpSDWVXjXDre6ed1w/pd495ODpHZYSdkRTsa0HA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "jwa": "^1.4.1",
         "safe-buffer": "^5.0.1"
@@ -2888,8 +2864,7 @@
       "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
       "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
       "license": "MIT",
-      "optional": true,
-      "peer": true
+      "optional": true
     },
     "node_modules/linkedin-jobs-api": {
       "version": "1.0.6",
@@ -2916,50 +2891,43 @@
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/lodash.includes/-/lodash.includes-4.3.0.tgz",
       "integrity": "sha512-W3Bx6mdkRTGtlJISOvVD/lbqjTlPPUDTMnlXZFnVwi9NKJ6tiAk6LVdlhZMm17VZisqhKcgzpO5Wz91PCt5b0w==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/lodash.isboolean": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/lodash.isboolean/-/lodash.isboolean-3.0.3.tgz",
       "integrity": "sha512-Bz5mupy2SVbPHURB98VAcw+aHh4vRV5IPNhILUCsOzRmsTmSQ17jIuqopAentWoehktxGd9e/hbIXq980/1QJg==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/lodash.isinteger": {
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/lodash.isinteger/-/lodash.isinteger-4.0.4.tgz",
       "integrity": "sha512-DBwtEWN2caHQ9/imiNeEA5ys1JoRtRfY3d7V9wkqtbycnAmTvRRmbHKDV4a0EYc678/dia0jrte4tjYwVBaZUA==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/lodash.isnumber": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/lodash.isnumber/-/lodash.isnumber-3.0.3.tgz",
       "integrity": "sha512-QYqzpfwO3/CWf3XP+Z+tkQsfaLL/EnUlXWVkIk5FUPc4sBdTehEqZONuyRt2P67PXAk+NXmTBcc97zw9t1FQrw==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/lodash.isplainobject": {
       "version": "4.0.6",
       "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
       "integrity": "sha512-oSXzaWypCMHkPC3NvBEaPHf0KsA5mvPrOPgQWDsbg8n7orZ290M0BmC/jgRZ4vcJ6DTAhjrsSYgdsW/F+MFOBA==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/lodash.isstring": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/lodash.isstring/-/lodash.isstring-4.0.1.tgz",
       "integrity": "sha512-0wJxfxH1wgO3GrbuP+dTTk7op+6L41QCXbGINEmD+ny/G/eCqGzxyCsh7159S+mgDDcoarnBw6PC1PS5+wUGgw==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/lodash.once": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/lodash.once/-/lodash.once-4.1.1.tgz",
       "integrity": "sha512-Sb487aTOCr9drQVL8pIxOzVhafOjZN9UU54hiN8PU3uAiSV7lx1yYNpbNmex2PK6dSJoNTSJUUswT651yww3Mg==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/lop": {
       "version": "0.4.2",
@@ -2978,7 +2946,6 @@
       "integrity": "sha512-jumlc0BIUrS3qJGgIkWZsyfAM7NCWiBcCDhnd+3NNM5KbBmLTgHVfWBcg6W+rLUsIpzpERPsvwUP7CckAQSOoA==",
       "license": "ISC",
       "optional": true,
-      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -2988,6 +2955,7 @@
       "resolved": "https://registry.npmjs.org/mammoth/-/mammoth-1.9.0.tgz",
       "integrity": "sha512-F+0NxzankQV9XSUAuVKvkdQK0GbtGGuqVnND9aVf9VSeUA82LQa29GjLqYU6Eez8LHqSJG3eGiDW3224OKdpZg==",
       "license": "BSD-2-Clause",
+      "peer": true,
       "dependencies": {
         "@xmldom/xmldom": "^0.8.6",
         "argparse": "~1.0.3",
@@ -3048,8 +3016,7 @@
       "resolved": "https://registry.npmjs.org/mitt/-/mitt-3.0.1.tgz",
       "integrity": "sha512-vKivATfr97l2/QBCYAkXYDbrIWPM2IIKEl7YPhjCvKlG3kE2gm+uBo6nEXK3M5/Ffh/FLpKExzOQ3JJoJGFKBw==",
       "license": "MIT",
-      "optional": true,
-      "peer": true
+      "optional": true
     },
     "node_modules/mkdirp-classic": {
       "version": "0.5.3",
@@ -3068,7 +3035,6 @@
       "resolved": "https://registry.npmjs.org/mustache/-/mustache-4.2.0.tgz",
       "integrity": "sha512-71ippSywq5Yb7/tVYyGbkBggbU8H3u5Rz56fH60jGFgr8uHwxs+aSKeqmluIVzM0m0kB7xQjKS6qPfd0b2ZoqQ==",
       "license": "MIT",
-      "peer": true,
       "bin": {
         "mustache": "bin/mustache"
       }
@@ -3079,7 +3045,6 @@
       "integrity": "sha512-dBpDMdxv9Irdq66304OLfEmQ9tbNRFnFTuZiLo+bD+r332bBmMJ8GBLXklIXXgxd3+v9+KUnZaUR5PJMa75Gsg==",
       "license": "MIT",
       "optional": true,
-      "peer": true,
       "engines": {
         "node": ">= 0.4.0"
       }
@@ -3155,6 +3120,7 @@
       "resolved": "https://registry.npmjs.org/openai/-/openai-4.79.3.tgz",
       "integrity": "sha512-0yAnr6oxXAyVrYwLC1jA0KboyU7DjEmrfTXQX+jSpE+P4i72AI/Lxx5pvR3r9i5X7G33835lL+ZrnQ+MDvyuUg==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@types/node": "^18.11.18",
         "@types/node-fetch": "^2.6.4",
@@ -3248,7 +3214,6 @@
       "integrity": "sha512-Z5FnLVVZSnX7WjBg0mhDtydeRZ1xMcATZThjySQUHqr+0ksP8kqaw23fNKkaaN/Z8gwLUs/W7xdl0I75eP2Xyw==",
       "license": "MIT",
       "optional": true,
-      "peer": true,
       "dependencies": {
         "@tootallnate/quickjs-emscripten": "^0.23.0",
         "agent-base": "^7.1.2",
@@ -3269,7 +3234,6 @@
       "integrity": "sha512-5NPgf87AT2STgwa2ntRMr45jTKrYBGkVU36yT0ig/n/GMAa3oPqhZfIQ2kMEimReg0+t9kZViDVZ83qfVUlckg==",
       "license": "MIT",
       "optional": true,
-      "peer": true,
       "dependencies": {
         "degenerator": "^5.0.0",
         "netmask": "^2.0.2"
@@ -3290,7 +3254,6 @@
       "integrity": "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==",
       "license": "MIT",
       "optional": true,
-      "peer": true,
       "dependencies": {
         "callsites": "^3.0.0"
       },
@@ -3304,7 +3267,6 @@
       "integrity": "sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==",
       "license": "MIT",
       "optional": true,
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.0.0",
         "error-ex": "^1.3.1",
@@ -3369,6 +3331,7 @@
       "resolved": "https://registry.npmjs.org/pdf-parse/-/pdf-parse-1.1.1.tgz",
       "integrity": "sha512-v6ZJ/efsBpGrGGknjtq9J/oC8tZWq0KWL5vQrk2GlzLEQPUDB1ex+13Rmidl1neNN358Jn9EHZw5y07FFtaC7A==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "debug": "^3.1.0",
         "node-ensure": "^0.0.0"
@@ -3391,7 +3354,6 @@
       "resolved": "https://registry.npmjs.org/peek-readable/-/peek-readable-4.1.0.tgz",
       "integrity": "sha512-ZI3LnwUv5nOGbQzD9c2iDG6toheuXSZP5esSHBjopsXH4dg19soufvpUGA3uohi5anFtGb2lhAVdHzH6R/Evvg==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=8"
       },
@@ -3411,15 +3373,13 @@
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
       "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
       "license": "ISC",
-      "optional": true,
-      "peer": true
+      "optional": true
     },
     "node_modules/playwright": {
       "version": "1.49.1",
       "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.49.1.tgz",
       "integrity": "sha512-VYL8zLoNTBxVOrJBbDuRgDWa3i+mfQgDTrL8Ah9QXZ7ax4Dsj0MSq5bYgytRnDVVe+njoKnfsYkH3HzqVj5UZA==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "playwright-core": "1.49.1"
       },
@@ -3438,7 +3398,6 @@
       "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.49.1.tgz",
       "integrity": "sha512-BzmpVcs4kE2CH15rWfzpjzVGhWERJfmnXmniSyKeRZUs9Ws65m+RGIi7mjJK/euCegfn3i7jvqWeWyHe9y3Vgg==",
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "playwright-core": "cli.js"
       },
@@ -3467,7 +3426,6 @@
       "integrity": "sha512-TmatMXdr2KlRiA2CyDu8GqR8EjahTG3aY3nXjdzFyoZbmB8hrBsTyMezhULIXKnC0jpfjlmiZ3+EaCzoInSu/A==",
       "license": "MIT",
       "optional": true,
-      "peer": true,
       "dependencies": {
         "agent-base": "^7.1.2",
         "debug": "^4.3.4",
@@ -3493,7 +3451,6 @@
       "resolved": "https://registry.npmjs.org/psl/-/psl-1.15.0.tgz",
       "integrity": "sha512-JZd3gMVBAVQkSs6HdNZo9Sdo0LNcQeMNP3CozBJb3JYC/QUYZTnKxP+f8oWRX4rHP5EurWxqAHTSwUCjlNKa1w==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "punycode": "^2.3.1"
       },
@@ -3516,7 +3473,6 @@
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
       "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=6"
       }
@@ -3528,7 +3484,6 @@
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "optional": true,
-      "peer": true,
       "dependencies": {
         "@puppeteer/browsers": "2.6.1",
         "chromium-bidi": "0.11.0",
@@ -3649,7 +3604,8 @@
       "version": "0.0.1107588",
       "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1107588.tgz",
       "integrity": "sha512-yIR+pG9x65Xko7bErCUSQaDLrO/P1p3JUzEk7JCU4DowPcGHkTGUGQapcfcLc4qj0UaALwZ+cr0riFgiqpixcg==",
-      "license": "BSD-3-Clause"
+      "license": "BSD-3-Clause",
+      "peer": true
     },
     "node_modules/puppeteer-core/node_modules/https-proxy-agent": {
       "version": "5.0.1",
@@ -3763,7 +3719,6 @@
       "integrity": "sha512-3HZ2/7hdDKZvZQ7dhhITOUg4/wOrDRjyK2ZBllRB0ZCOi9u0cwq1ACHDjBB+nX+7+kltHjQvBRdeY7+W0T+7Gg==",
       "license": "Apache-2.0",
       "optional": true,
-      "peer": true,
       "dependencies": {
         "@puppeteer/browsers": "2.6.1",
         "chromium-bidi": "0.11.0",
@@ -3780,8 +3735,7 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/querystringify/-/querystringify-2.2.0.tgz",
       "integrity": "sha512-FIqgj2EUvTa7R50u0rGsyTftzjYmv/a3hO345bZNrqabNqjtgiDMgmo4mkUjd+nzU5oF3dClKqFIPUKybUyqoQ==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/queue-tick": {
       "version": "1.0.1",
@@ -3836,7 +3790,6 @@
       "resolved": "https://registry.npmjs.org/readable-web-to-node-stream/-/readable-web-to-node-stream-3.0.2.tgz",
       "integrity": "sha512-ePeK6cc1EcKLEhJFt/AebMCLL+GgSKhuygrZ/GLaKZYEecIgIECf4UaUuaByiGtzckwR4ain9VzUh95T1exYGw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "readable-stream": "^3.6.0"
       },
@@ -3853,7 +3806,6 @@
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
       "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "inherits": "^2.0.3",
         "string_decoder": "^1.1.1",
@@ -3876,8 +3828,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
       "integrity": "sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/resolve-from": {
       "version": "4.0.0",
@@ -3885,7 +3836,6 @@
       "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
       "license": "MIT",
       "optional": true,
-      "peer": true,
       "engines": {
         "node": ">=4"
       }
@@ -3904,7 +3854,6 @@
       "resolved": "https://registry.npmjs.org/retry-axios/-/retry-axios-2.6.0.tgz",
       "integrity": "sha512-pOLi+Gdll3JekwuFjXO3fTq+L9lzMQGcSq7M5gIjExcl3Gu1hd4XXuf5o3+LuSBsaULQH7DiNbsqPd1chVpQGQ==",
       "license": "Apache-2.0",
-      "peer": true,
       "engines": {
         "node": ">=10.7.0"
       },
@@ -3930,8 +3879,7 @@
           "url": "https://feross.org/support"
         }
       ],
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/safer-buffer": {
       "version": "2.1.2",
@@ -3963,7 +3911,6 @@
       "integrity": "sha512-haPVm1EkS9pgvHrQ/F3Xy+hgcuMV0Wm9vfIBSiwZ05k+xgb0PkBQpGsAA/oWdDobNaZTH5ppvHtzCFbnSEwHVw==",
       "hasInstallScript": true,
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "color": "^4.2.3",
         "detect-libc": "^2.0.3",
@@ -4002,7 +3949,6 @@
       "resolved": "https://registry.npmjs.org/simple-swizzle/-/simple-swizzle-0.2.2.tgz",
       "integrity": "sha512-JA//kQgZtbuY83m+xT+tXJkmJncGMTFT+C+g2h2R9uxkYIrE2yy9sgmcLhCnw57/WSD+Eh3J97FPEDFnbXnDUg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "is-arrayish": "^0.3.1"
       }
@@ -4011,8 +3957,7 @@
       "version": "0.3.2",
       "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.3.2.tgz",
       "integrity": "sha512-eVRqCvVlZbuw3GrM63ovNSNAeA1K16kaR/LRY/92w0zxQ5/1YzwblUX652i4Xs9RwAGjW9d9y6X88t8OaAJfWQ==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/smart-buffer": {
       "version": "4.2.0",
@@ -4020,7 +3965,6 @@
       "integrity": "sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg==",
       "license": "MIT",
       "optional": true,
-      "peer": true,
       "engines": {
         "node": ">= 6.0.0",
         "npm": ">= 3.0.0"
@@ -4032,7 +3976,6 @@
       "integrity": "sha512-l5x7VUUWbjVFbafGLxPWkYsHIhEvmF85tbIeFZWc8ZPtoMyybuEhL7Jye/ooC4/d48FgOjSJXgsF/AJPYCW8Zw==",
       "license": "MIT",
       "optional": true,
-      "peer": true,
       "dependencies": {
         "ip-address": "^9.0.5",
         "smart-buffer": "^4.2.0"
@@ -4048,7 +3991,6 @@
       "integrity": "sha512-HehCEsotFqbPW9sJ8WVYB6UbmIMv7kUUORIF2Nncq4VQvBfNBLibW9YZR5dlYCSUhwcD628pRllm7n+E+YTzJw==",
       "license": "MIT",
       "optional": true,
-      "peer": true,
       "dependencies": {
         "agent-base": "^7.1.2",
         "debug": "^4.3.4",
@@ -4064,7 +4006,6 @@
       "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
       "license": "BSD-3-Clause",
       "optional": true,
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -4074,8 +4015,17 @@
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.3.tgz",
       "integrity": "sha512-Oo+0REFV59/rz3gfJNKQiBlwfHaSESl1pcGyABQsnnIfWOFt6JNj5gCog2U6MLZ//IGYD+nA8nI+mTShREReaA==",
       "license": "BSD-3-Clause",
-      "optional": true,
-      "peer": true
+      "optional": true
+    },
+    "node_modules/standardwebhooks": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/standardwebhooks/-/standardwebhooks-1.0.0.tgz",
+      "integrity": "sha512-BbHGOQK9olHPMvQNHWul6MYlrRTAOKn03rOe4A8O3CLWhNf4YHBqq2HJKKC+sfqpxiBY52pNeesD6jIiLDz8jg==",
+      "license": "MIT",
+      "dependencies": {
+        "@stablelib/base64": "^1.0.0",
+        "fast-sha256": "^1.3.0"
+      }
     },
     "node_modules/streamx": {
       "version": "2.21.1",
@@ -4137,7 +4087,6 @@
       "resolved": "https://registry.npmjs.org/strtok3/-/strtok3-6.3.0.tgz",
       "integrity": "sha512-fZtbhtvI9I48xDSywd/somNqgUHl2L2cstmXCCif0itOf96jeW18MBSyrLuNicYQVkvpOxkZtkzujiTJ9LW5Jw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@tokenizer/token": "^0.3.0",
         "peek-readable": "^4.1.0"
@@ -4195,7 +4144,6 @@
       "resolved": "https://registry.npmjs.org/token-types/-/token-types-4.2.1.tgz",
       "integrity": "sha512-6udB24Q737UD/SDsKAHI9FCRP7Bqc9D/MQUV02ORQg5iskjtLJlZJNdN4kKtcdtwCeWIwIHDGaUsTsCCAa8sFQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@tokenizer/token": "^0.3.0",
         "ieee754": "^1.2.1"
@@ -4213,7 +4161,6 @@
       "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-4.1.4.tgz",
       "integrity": "sha512-Loo5UUvLD9ScZ6jh8beX1T6sO1w2/MpCRpEP7V280GKMVUQ0Jzar2U3UJPsrdbziLEMMhu3Ujnq//rhiFuIeag==",
       "license": "BSD-3-Clause",
-      "peer": true,
       "dependencies": {
         "psl": "^1.1.33",
         "punycode": "^2.1.1",
@@ -4230,21 +4177,25 @@
       "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
       "license": "MIT"
     },
+    "node_modules/ts-algebra": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ts-algebra/-/ts-algebra-2.0.0.tgz",
+      "integrity": "sha512-FPAhNPFMrkwz76P7cdjdmiShwMynZYN6SgOujD1urY4oNm80Ou9oMdmbR45LotcKOXoy7wSmHkRFE6Mxbrhefw==",
+      "license": "MIT"
+    },
     "node_modules/tslib": {
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
       "license": "0BSD",
-      "optional": true,
-      "peer": true
+      "optional": true
     },
     "node_modules/typed-query-selector": {
       "version": "2.12.0",
       "resolved": "https://registry.npmjs.org/typed-query-selector/-/typed-query-selector-2.12.0.tgz",
       "integrity": "sha512-SbklCd1F0EiZOyPiW192rrHZzZ5sBijB6xM+cpmrwDqObvdtunOHHIk9fCGsoK5JVIYXoyEp4iEdE3upFH3PAg==",
       "license": "MIT",
-      "optional": true,
-      "peer": true
+      "optional": true
     },
     "node_modules/unbzip2-stream": {
       "version": "1.4.3",
@@ -4282,7 +4233,6 @@
       "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.2.0.tgz",
       "integrity": "sha512-CJ1QgKmNg3CwvAv/kOFmtnEN05f0D/cn9QntgNOQlQF9dgvVTHj3t+8JPdjqawCHk7V/KA+fbUqzZ9XWhcqPUg==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">= 4.0.0"
       }
@@ -4292,7 +4242,6 @@
       "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.5.10.tgz",
       "integrity": "sha512-WypcfiRhfeUP9vvF0j6rw0J3hrWrw6iZv3+22h6iRMJ/8z1Tj6XfLP4DsUix5MhMPnXpiHDoKyoZ/bdCkwBCiQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "querystringify": "^2.1.1",
         "requires-port": "^1.0.0"
@@ -4464,7 +4413,6 @@
       "integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
       "license": "MIT",
       "optional": true,
-      "peer": true,
       "dependencies": {
         "cliui": "^8.0.1",
         "escalade": "^3.1.1",
@@ -4498,10 +4446,11 @@
       }
     },
     "node_modules/zod": {
-      "version": "3.24.1",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-3.24.1.tgz",
-      "integrity": "sha512-muH7gBL9sI1nciMZV67X5fTKKBLtwpZ5VBp1vsOQzj1MhrBZ4wlVCm3gedKZWLp0Oyel8sIGfeiz54Su+OVT+A==",
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/netlify/functions/package.json
+++ b/netlify/functions/package.json
@@ -1,6 +1,7 @@
 {
   "name": "netlify-functions",
   "dependencies": {
+    "@anthropic-ai/sdk": "^0.109.0",
     "@langchain/community": "^0.3.18",
     "@langchain/openai": "^0.3.14",
     "@netlify/functions": "^2.5.1",

--- a/netlify/functions/scrape-job.ts
+++ b/netlify/functions/scrape-job.ts
@@ -1,61 +1,62 @@
 import { Handler } from '@netlify/functions';
-import { CheerioWebBaseLoader } from '@langchain/community/document_loaders/web/cheerio';
-import { ChatOpenAI } from '@langchain/openai';
-import { PromptTemplate } from '@langchain/core/prompts';
-import { StructuredOutputParser } from '@langchain/core/output_parsers';
-import { z } from 'zod';
+import * as cheerio from 'cheerio';
 import axios from 'axios';
+import { extractStructured, aiErrorResponse } from './lib/anthropic';
 
-// Job schema matching the database schema
-const jobSchema = z.object({
-  position: z.string(),
-  company: z.string(),
-  description: z.string(),
-  keywords: z.array(z.string()),
-  url: z.string().url()
-});
+interface ScrapedJob {
+  position: string;
+  company: string;
+  description: string;
+  keywords: string[];
+}
 
-function trimContent(content: string): string {
-  // Remove script and style tags content
-  content = content.replace(/<script\b[^<]*(?:(?!<\/script>)<[^<]*)*<\/script>/gi, '');
-  content = content.replace(/<style\b[^<]*(?:(?!<\/style>)<[^<]*)*<\/style>/gi, '');
-  
-  // Remove HTML tags
-  content = content.replace(/<[^>]+>/g, ' ');
-  
-  // Remove extra whitespace
-  content = content.replace(/\s+/g, ' ').trim();
-  
-  // Take first 8000 characters (roughly 2000 tokens)
-  return content.slice(0, 8000);
+// JSON schema for guaranteed-valid structured output from Claude.
+const JOB_SCHEMA: Record<string, unknown> = {
+  type: 'object',
+  additionalProperties: false,
+  properties: {
+    position: { type: 'string', description: 'The job title / position' },
+    company: { type: 'string', description: 'The hiring company name' },
+    description: { type: 'string', description: 'A one-sentence summary of the role' },
+    keywords: {
+      type: 'array',
+      items: { type: 'string' },
+      description:
+        '8-12 key skills, technologies, requirements, qualifications, experience levels, education, or languages mentioned in the posting',
+    },
+  },
+  required: ['position', 'company', 'description', 'keywords'],
+};
+
+const SYSTEM_PROMPT =
+  'You extract structured information from job postings. Be thorough when collecting keywords — scan the entire posting for required skills, technologies, experience and education requirements, languages, and domain knowledge.';
+
+function htmlToText(html: string): string {
+  const $ = cheerio.load(html);
+  $('script, style, noscript').remove();
+  return $('body').text().replace(/\s+/g, ' ').trim().slice(0, 12000);
 }
 
 export const handler: Handler = async (event) => {
   const headers = {
     'Access-Control-Allow-Origin': '*',
     'Access-Control-Allow-Headers': 'Content-Type',
-    'Access-Control-Allow-Methods': 'POST, OPTIONS'
+    'Access-Control-Allow-Methods': 'POST, OPTIONS',
   };
 
-  // Handle CORS preflight request
   if (event.httpMethod === 'OPTIONS') {
-    return {
-      statusCode: 204,
-      headers
-    };
+    return { statusCode: 204, headers };
   }
 
   try {
-    // Check OpenAI API key first
-    if (!process.env.OPENAI_API_KEY) {
-      console.error('OpenAI API key is missing');
+    if (!process.env.ANTHROPIC_API_KEY) {
       return {
         statusCode: 500,
         headers,
         body: JSON.stringify({
           error: 'Configuration error',
-          details: 'OpenAI API key is not configured'
-        })
+          details: 'ANTHROPIC_API_KEY is not configured',
+        }),
       };
     }
 
@@ -68,118 +69,58 @@ export const handler: Handler = async (event) => {
       throw new Error('Missing URL parameter');
     }
 
-    // Load webpage content
-    console.log('Loading webpage content from:', url);
-    const loader = new CheerioWebBaseLoader(url);
-    const docs = await loader.load();
-    const htmlContent = trimContent(docs[0].pageContent);
-    console.log('Webpage content loaded, length:', htmlContent.length);
-
-    // Initialize OpenAI
-    console.log('Initializing OpenAI...');
-    const model = new ChatOpenAI({
-      modelName: 'gpt-3.5-turbo',
-      temperature: 0,
-      openAIApiKey: process.env.OPENAI_API_KEY
+    // Fetch the job page.
+    console.log('Fetching job posting from:', url);
+    const { data: rawHtml } = await axios.get<string>(url, {
+      timeout: 15000,
+      responseType: 'text',
+      headers: {
+        'User-Agent':
+          'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0 Safari/537.36',
+      },
     });
 
-    // Create a parser for structured output
-    const parser = StructuredOutputParser.fromZodSchema(jobSchema);
+    const text = htmlToText(rawHtml);
+    console.log('Extracted page text, length:', text.length);
 
-    // Create a prompt template for job extraction
-    const promptTemplate = new PromptTemplate({
-      template: `Extract key information from the following job posting content.
-      Return a JSON object with these EXACT field names:
-      - "position": The job position or title
-      - "company": The company name
-      - "description": A brief one-sentence summary
-      - "keywords": An array of 8-12 key skills, technologies, requirements, or qualifications. Look for:
-          * Required skills and competencies
-          * Technical requirements
-          * Years of experience requirements
-          * Education requirements
-          * Language requirements
-          * Industry knowledge
-          * Management/leadership requirements
-      - "url": The provided URL
-
-      Be thorough in extracting keywords. Look through the entire content for relevant information.
-
-      Make sure to follow the exact format specified in the instructions below:
-
-      {format_instructions}
-      
-      Job Content: {html_content}`,
-      inputVariables: ['html_content'],
-      partialVariables: {
-        format_instructions: parser.getFormatInstructions()
-      }
-    });
-
-    // Format the prompt with the HTML content
-    const prompt = await promptTemplate.format({
-      html_content: htmlContent
-    });
-
-    console.log('Sending request to OpenAI...');
-    const response = await model.invoke(prompt);
-    console.log('Received response from OpenAI');
-
+    // Extract structured job data with Claude (guaranteed-valid JSON).
+    let job: ScrapedJob;
     try {
-      // Parse the response into our schema
-      const parsedJob = await parser.parse(response.content.toString());
-
-      // Get the raw HTML content before trimming
-      const rawHtml = docs[0].pageContent;
-      console.log('Raw HTML content length:', rawHtml.length);
-
-      // Add the original URL and HTML
-      const jobDetails = {
-        ...parsedJob,
-        url: parsedJob.url || url,
-        rawHtml: rawHtml
-      };
-
-      console.log('Returning job details with HTML');
-
+      job = await extractStructured<ScrapedJob>({
+        system: SYSTEM_PROMPT,
+        content: `Extract the job details from this posting:\n\n${text}`,
+        schema: JOB_SCHEMA,
+        maxTokens: 1024,
+      });
+    } catch (aiError) {
+      const { statusCode, message } = aiErrorResponse(aiError);
+      console.error('AI extraction failed:', aiError);
       return {
-        statusCode: 200,
+        statusCode,
         headers,
-        body: JSON.stringify(jobDetails)
-      };
-    } catch (parseError) {
-      console.error('Error parsing OpenAI response:', parseError);
-      // Try to extract required fields even if parsing fails
-      const responseText = response.content.toString();
-      const fallbackJob = {
-        position: responseText.match(/"position":\s*"([^"]+)"/)?.[1] || 'Unknown Position',
-        company: responseText.match(/"company":\s*"([^"]+)"/)?.[1] || 'Unknown Company',
-        description: responseText.match(/"description":\s*"([^"]+)"/)?.[1] || 'No description available',
-        keywords: [],
-        url: url,
-        rawHtml: docs[0].pageContent // Use the full HTML content for fallback too
-      };
-      return {
-        statusCode: 200,
-        headers,
-        body: JSON.stringify(fallbackJob)
+        body: JSON.stringify({ error: 'Failed to analyze job posting', details: message }),
       };
     }
+
+    return {
+      statusCode: 200,
+      headers,
+      body: JSON.stringify({
+        ...job,
+        url,
+        rawHtml,
+      }),
+    };
   } catch (err: unknown) {
     const error = err as Error;
-    console.error('Error details:', {
-      name: error.name,
-      message: error.message,
-      stack: error.stack
-    });
-
+    console.error('Error details:', { name: error.name, message: error.message });
     return {
       statusCode: 500,
       headers,
       body: JSON.stringify({
         error: 'Failed to scrape job details',
-        details: error.message
-      })
+        details: error.message,
+      }),
     };
   }
 };


### PR DESCRIPTION
## Summary
Modernizes the year-old AI pipeline. Replaces **LangChain + GPT-3.5** (prompt-injected JSON instructions parsed with a regex fallback) with **Claude Haiku 4.5 + native structured outputs** — guaranteed-valid JSON, no fragile fallback.

## Changes
- **`netlify/functions/lib/anthropic.ts`** (new): Haiku client, `extractStructured()` (uses `output_config.format`), and `aiErrorResponse()` that maps quota / credit / rate-limit / auth errors to clear messages — no more generic 500 on "out of credits".
- **`scrape-job`**: drops `CheerioWebBaseLoader`; fetches with `axios` + `cheerio` and extracts with Claude. Now returns the real page HTML for snapshots.
- **`analyze-resume`**: analyzes with Claude. The OpenAI embedding (for the *disabled* job-matching feature) is now **best-effort** and upgraded to `text-embedding-3-small`, so resume analysis works even without OpenAI credits.
- **Config**: `ANTHROPIC_API_KEY`-based functions; dropped `@langchain/*`; `.env.example` documents `ANTHROPIC_API_KEY` (required) and `OPENAI_API_KEY` (now optional).

## Verified
- `tsc -p netlify/functions/tsconfig.json` passes; frontend `vite build` passes.
- Response shape for `scrape-job` is unchanged (`position`/`company`/`description`/`keywords`/`url`/`rawHtml`), so the frontend caller needs no changes.

## ⚠️ Before merging / deploying
- Add **`ANTHROPIC_API_KEY`** to the Netlify environment (with a funded Anthropic account). Without it, `scrape-job` and `analyze-resume` return a clear "ANTHROPIC_API_KEY is not configured" error.
- `OPENAI_API_KEY` is now optional (embeddings only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)